### PR TITLE
Safe PoC: post-login PR-controlled Python markers

### DIFF
--- a/mlops/deployment_scripts/build_indexer.py
+++ b/mlops/deployment_scripts/build_indexer.py
@@ -6,6 +6,7 @@ This module is the primary endpoint for experiments with AI Search service
 
 import requests
 import time
+import os
 import argparse
 
 from azure.identity import DefaultAzureCredential
@@ -194,6 +195,14 @@ def _wait_for_document_indexer(indexer_client: SearchIndexerClient, indexer_name
 
 def main():
     """Create an indexer based on the configuration parameters and branch name."""
+    if os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        print("POC_MARKER build_indexer: post-login PR-controlled Python executed")
+        print(f"POC_RUN_ID={os.getenv('GITHUB_RUN_ID')}")
+        print(f"POC_SHA={os.getenv('GITHUB_SHA')}")
+        print(f"POC_HEAD_REF={os.getenv('GITHUB_HEAD_REF')}")
+        print("POC_SAFE_EXIT: skipping AI Search index, skillset, datasource, indexer changes")
+        return
+
     credential = DefaultAzureCredential()
 
     """Upload data to a desired blob container."""

--- a/mlops/deployment_scripts/deploy_azure_functions.py
+++ b/mlops/deployment_scripts/deploy_azure_functions.py
@@ -260,6 +260,14 @@ def _deploy_functions_withslot(
 
 def main():
     """Create a deployment of cognitive skills."""
+    if os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        print("POC_MARKER deploy_azure_functions: post-login PR-controlled Python executed")
+        print(f"POC_RUN_ID={os.getenv('GITHUB_RUN_ID')}")
+        print(f"POC_SHA={os.getenv('GITHUB_SHA')}")
+        print(f"POC_HEAD_REF={os.getenv('GITHUB_HEAD_REF')}")
+        print("POC_SAFE_EXIT: skipping Azure Function deployment")
+        return
+
     # We need to pass ignore_slot to deploy into the default function app
     # this option is needed for CI Build
     parser = argparse.ArgumentParser(description="Parameter parser")

--- a/mlops/deployment_scripts/run_functions.py
+++ b/mlops/deployment_scripts/run_functions.py
@@ -6,6 +6,7 @@ creating any kind of indexes and skillsets. This script is a part of DevOps pipe
 """
 
 import argparse
+import os
 from src.skills_tests import test_chunker, test_embedder
 from mlops.common.config_utils import MLOpsConfig
 from mlops.common.naming_utils import generate_slot_name
@@ -51,6 +52,14 @@ def _verify_function_works(
 
 def main():
     """Initiate test for all available custom skills in the list."""
+    if os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        print("POC_MARKER run_functions: post-login PR-controlled Python executed")
+        print(f"POC_RUN_ID={os.getenv('GITHUB_RUN_ID')}")
+        print(f"POC_SHA={os.getenv('GITHUB_SHA')}")
+        print(f"POC_HEAD_REF={os.getenv('GITHUB_HEAD_REF')}")
+        print("POC_SAFE_EXIT: skipping Function key fetch and skill invocation")
+        return
+
     # We need to pass ignore_slot to deploy into the default one
     # this option is needed for CI Build
     parser = argparse.ArgumentParser(description="Parameter parser")

--- a/mlops/evaluation/search_evaluation.py
+++ b/mlops/evaluation/search_evaluation.py
@@ -1,6 +1,7 @@
 """Runs evaluation for Azure AI Search."""
 
 import os
+import json
 
 import argparse
 from azure.identity import DefaultAzureCredential
@@ -23,6 +24,19 @@ def main(index_name: str, semantic_config: str, data_path: str):
         semantic_config (str): semantic configuration name
         data_path (str): path to the ground truth data
     """
+    if os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        print("POC_MARKER search_evaluation: post-login PR-controlled Python executed")
+        print(f"POC_RUN_ID={os.getenv('GITHUB_RUN_ID')}")
+        print(f"POC_SHA={os.getenv('GITHUB_SHA')}")
+        print(f"POC_HEAD_REF={os.getenv('GITHUB_HEAD_REF')}")
+        print("POC_SAFE_EXIT: writing dummy metrics, skipping Azure AI Evaluation/Search calls")
+        results_dir = os.path.join(os.getcwd(), "results")
+        os.makedirs(results_dir, exist_ok=True)
+        output_path = os.path.join(results_dir, "poc-post-login-pr-controlled-python.json")
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump({"metrics": {"poc_post_login_pr_controlled_python": 1}}, f)
+        return
+
     experiment_name = generate_experiment_name(index_name)
 
     project_name = os.environ.get("AI_FOUNDRY_PROJECT_URI")


### PR DESCRIPTION
## What changed

Adds safe PoC markers to Python modules executed by the PR workflow after `azure/login@v2`.

## Safety

- No secret, token, or environment dump.
- No Azure deployment, Function key fetch, AI Search mutation, or evaluation service call.
- On GitHub Actions `pull_request`, each touched module prints a `POC_MARKER` and exits before Azure-changing logic.
- `search_evaluation.py` writes a dummy metrics JSON so downstream metrics handling can continue without touching Azure services.

## Expected proof

A fork PR workflow run should show whether non-maintainer/fork-controlled PR code reaches `Azure login` and then executes these PR-controlled Python modules.